### PR TITLE
Add Content-type header to server plugin requests

### DIFF
--- a/models/plugin/server/http.go
+++ b/models/plugin/server/http.go
@@ -84,6 +84,7 @@ func (p *httpPlugin) do(ctx context.Context, r *Request, res *Response) error {
 	}
 	req = req.WithContext(ctx)
 	req.Header.Set("X-Frp-Reqid", GetReqidFromContext(ctx))
+	req.Header.Set("Content-type", "application/json")
 	resp, err := p.client.Do(req)
 	if err != nil {
 		return err


### PR DESCRIPTION
Add Content-type header to server plugin requests, this is necessary for API servers such as ASP.NET Core which will not accept requests without the correct Content-type.